### PR TITLE
fix/NEX-1158/firefox-keyboard-focus

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "focus-visible",
+  "name": "@oat-sa/focus-visible",
   "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-visible",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "focus-visible",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Polyfill for :focus-visible pseudo-selector",
   "scripts": {
     "build": "rollup -c",
@@ -23,14 +23,13 @@
   "main": "dist/focus-visible.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/WICG/focus-visible.git"
+    "url": "https://github.com/oat-sa/focus-visible.git"
   },
-  "author": "WICG",
   "license": "W3C",
   "bugs": {
-    "url": "https://github.com/WICG/focus-visible/issues"
+    "url": "https://github.com/oat-sa/focus-visible/issues"
   },
-  "homepage": "https://github.com/WICG/focus-visible",
+  "homepage": "https://github.com/oat-sa/focus-visible",
   "devDependencies": {
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "ajv": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "focus-visible",
+  "name": "@oat-sa/focus-visible",
   "version": "5.1.1",
   "description": "Polyfill for :focus-visible pseudo-selector",
   "scripts": {
@@ -24,6 +24,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/oat-sa/focus-visible.git"
+  },
+  "publishConfig": {
+    "access": "public"
   },
   "license": "W3C",
   "bugs": {

--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -144,9 +144,11 @@ function applyFocusVisiblePolyfill(scope) {
     }
 
     if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
-      //previous item should be unfocused before setting new focus
-      if(focusedElement){
-        focusedElement.blur();
+      //in normal way focusedElement always should be null here
+      //if not - should be unfocused before setting new focus
+      if (focusedElement) {
+        //we shouldn't fire blur event here, because of element can be disabled
+        removeFocusVisibleClass(e.target);
       }
       addFocusVisibleClass(e.target);
       focusedElement = e.target;

--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -9,6 +9,7 @@ function applyFocusVisiblePolyfill(scope) {
   var hadKeyboardEvent = true;
   var hadFocusVisibleRecently = false;
   var hadFocusVisibleRecentlyTimeout = null;
+  var focusedElement = null;
 
   var inputTypesWhitelist = {
     text: true,
@@ -143,7 +144,12 @@ function applyFocusVisiblePolyfill(scope) {
     }
 
     if (hadKeyboardEvent || focusTriggersKeyboardModality(e.target)) {
+      //previous item should be unfocused before setting new focus
+      if(focusedElement){
+        focusedElement.blur();
+      }
       addFocusVisibleClass(e.target);
+      focusedElement = e.target;
     }
   }
 
@@ -170,6 +176,7 @@ function applyFocusVisiblePolyfill(scope) {
         hadFocusVisibleRecently = false;
       }, 100);
       removeFocusVisibleClass(e.target);
+      focusedElement = null;
     }
   }
 


### PR DESCRIPTION
Related to: https://github.com/WICG/focus-visible/issues/231

Changes:

   - Unfocusing active element before buttons disabling

Steps to reproduce:

   - Render non-linear test
   - Using KB navigation set focus on an navigation bar item
   - Press Enter button
   - Start pressing TAB when test item loading is in progress

How to test fix:

   - Repeat steps to reproduce
   - Visually check that focusing border removed from item on start loading

Reason:

When Enter button pressed and test item starts to load, each navbar button is switched to disabled state.
If in this moment button is focused, than it loses this focus without firing blur event

DEMO: https://codesandbox.io/s/angry-lovelace-z8i6h?file=/src/index.js

