### PR TITLE
Update focusing target

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/focus-visible",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oat-sa/focus-visible",
-  "version": "5.1.1",
+  "version": "5.1.2",
   "description": "Polyfill for :focus-visible pseudo-selector",
   "scripts": {
     "build": "rollup -c",

--- a/src/focus-visible.js
+++ b/src/focus-visible.js
@@ -148,7 +148,7 @@ function applyFocusVisiblePolyfill(scope) {
       //if not - should be unfocused before setting new focus
       if (focusedElement) {
         //we shouldn't fire blur event here, because of element can be disabled
-        removeFocusVisibleClass(e.target);
+        removeFocusVisibleClass(focusedElement);
       }
       addFocusVisibleClass(e.target);
       focusedElement = e.target;


### PR DESCRIPTION
Related to: https://oat-sa.atlassian.net/browse/NEX-1158

Changes:

 - 'focusedElement' is used now for removing focus-visible class instead of 'target'.

Steps to reproduce:

 - Render non-linear test
 - Using KB navigation set focus on an navigation bar item
 - Press Enter button
 - Start pressing TAB when test item loading is in progress

How to test fix:

 - Repeat steps to reproduce
 - Visually check that focusing border removed from item on start loading

Reason:

 - 'focusedElement' - the previously focused element. 
 - 'target' - current focused elementand. 
 Exactly 'focusedElement' should be unfocused before focusing new control.